### PR TITLE
fix alertify.prompt-constructor for title-parameter

### DIFF
--- a/src/js/prompt.js
+++ b/src/js/prompt.js
@@ -33,7 +33,7 @@
                     onok = _value;
                     oncancel = _onok;
                     break;
-                case 4:
+                case 5:
                     title = _title;
                     message = _message;
                     value = _value;


### PR DESCRIPTION
i was wondering why this doesn't work... :D

`alertify.prompt("Example", "This is a prompt dialog.", "Default value",
  function(evt, value ){
    alertify.success('Ok: ' + value);
  },
  function(){
    alertify.error('Cancel');
  })
  ;`
