### PR TITLE
add a feature: to hide other notifiers when dismissAll is true

### DIFF
--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -38,7 +38,8 @@
         transition:'pulse',
         notifier:{
             delay:5,
-            position:'bottom-right'
+            position:'bottom-right',
+            dismissAll: false
         },
         glossary:{
             title:'AlertifyJS',

--- a/src/js/notifier.js
+++ b/src/js/notifier.js
@@ -22,6 +22,7 @@
                 instance.__internal = {
                     position: alertify.defaults.notifier.position,
                     delay: alertify.defaults.notifier.delay,
+                    dismissAll: alertify.defaults.notifier.dismissAll,
                 };
 
                 element = document.createElement('DIV');
@@ -264,6 +265,9 @@
                     case 'delay':
                         this.__internal.delay = value;
                         break;
+                    case 'dismissAll':
+                        this.__internal.dismissAll = value;
+                        break;
                     }
                 }
                 return this;
@@ -293,6 +297,8 @@
                 //ensure notifier init
                 initialize(this);
                 //create new notification message
+                if(this.__internal && this.__internal.dismissAll == true)
+                    this.dismissAll();
                 var div = document.createElement('div');
                 div.className = classes.message + ((typeof type === 'string' && type !== '') ? ' ajs-' + type : '');
                 return create(div, callback);


### PR DESCRIPTION
AlertifyJS is very cool!!!Thanks all your work!

When we make a notifier, we want to dismiss the shown notifier.

So I add a option named 'notifier.dismissAll', default false.

If notifier.dismissAll is true, notifier will invoke dismissAll() method at first, and then, show itself.

My English is not good, God bless me typing this commit clearly.