### PR TITLE
Add feature: notifier option for a separate close button on messages

### DIFF
--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -38,7 +38,8 @@
         transition:'pulse',
         notifier:{
             delay:5,
-            position:'bottom-right'
+            position:'bottom-right',
+            closeButton:false
         },
         glossary:{
             title:'AlertifyJS',

--- a/src/js/notifier.js
+++ b/src/js/notifier.js
@@ -154,7 +154,15 @@
                         reflow = this.element.offsetWidth;
                         addClass(this.element, classes.visible);
                         // attach click event
-                        on(this.element, 'click', this.__internal.clickHandler);
+                        if (!alertify.defaults.notifier.closeButton) {
+                            on(this.element, 'click', this.__internal.clickHandler);
+                        } else {
+                            var close = document.createElement('span');
+                            addClass(close, 'ajs-close');
+                            addClass(this.element, 'ajs-has-close');
+                            this.element.appendChild(close);
+                            on(close, 'click', this.__internal.clickHandler);
+                        }
                         return this.delay(wait);
                     }
                     return this;

--- a/src/js/notifier.js
+++ b/src/js/notifier.js
@@ -10,7 +10,9 @@
                 bottom: 'ajs-bottom',
                 left: 'ajs-left',
                 visible: 'ajs-visible',
-                hidden: 'ajs-hidden'
+                hidden: 'ajs-hidden',
+                close: 'ajs-close',
+                hasClose: 'ajs-has-close'
             };
         /**
          * Helper: initializes the notifier instance
@@ -158,8 +160,8 @@
                             on(this.element, 'click', this.__internal.clickHandler);
                         } else {
                             var close = document.createElement('span');
-                            addClass(close, 'ajs-close');
-                            addClass(this.element, 'ajs-has-close');
+                            addClass(close, classes.close);
+                            addClass(this.element, classes.hasClose);
                             this.element.appendChild(close);
                             on(close, 'click', this.__internal.clickHandler);
                         }

--- a/src/js/notifier.js
+++ b/src/js/notifier.js
@@ -155,16 +155,6 @@
                         }
                         reflow = this.element.offsetWidth;
                         addClass(this.element, classes.visible);
-                        // attach click event
-                        if (!alertify.defaults.notifier.closeButton) {
-                            on(this.element, 'click', this.__internal.clickHandler);
-                        } else {
-                            var close = document.createElement('span');
-                            addClass(close, classes.close);
-                            addClass(this.element, classes.hasClose);
-                            this.element.appendChild(close);
-                            on(close, 'click', this.__internal.clickHandler);
-                        }
                         return this.delay(wait);
                     }
                     return this;
@@ -233,6 +223,15 @@
                     } else if (content instanceof window.HTMLElement && this.element.firstChild !== content) {
                         clearContents(this.element);
                         this.element.appendChild(content);
+                    }
+                    if (alertify.defaults.notifier.closeButton) {
+                        var close = document.createElement('span');
+                        addClass(close, classes.close);
+                        addClass(this.element, classes.hasClose);
+                        this.element.appendChild(close);
+                        on(close, 'click', this.__internal.clickHandler);
+                    } else {
+                        on(this.element, 'click', this.__internal.clickHandler);
                     }
                     return this;
                 },

--- a/src/less/alertify.less
+++ b/src/less/alertify.less
@@ -825,6 +825,9 @@
             max-height: 100%;
             padding: 15px;
             margin-top: 10px;
+            &.ajs-has-close {
+                padding-right:30px;
+            }
         }
 
         &.success {
@@ -837,6 +840,17 @@
 
         &.warning {
             background: rgba(252, 248, 215, 0.95);
+        }
+
+        .ajs-close {
+            position: absolute;
+            top: 0px;
+            right: 0px;
+            width:30px;
+            height:48px;
+            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAABGdBTUEAALGPC/xhBQAAAFBJREFUGBl1j0EKADEIA+ve/P9f9bh1hEihNBfjVCO1v7RKVqJK4h8gM5cAPR42AkQEpSXPwMTyoi13n5N9YqJehm3Fnr7nL1D0ZEbD5OubGyC7a9gx+9eNAAAAAElFTkSuQmCC);
+            background-repeat: no-repeat;
+            background-position: center center;
         }
     }
 

--- a/src/less/alertify.less
+++ b/src/less/alertify.less
@@ -825,7 +825,7 @@
             max-height: 100%;
             padding: 15px;
             margin-top: 10px;
-            &.ajs-has-close {
+            &.has-close {
                 padding-right:30px;
             }
         }
@@ -842,7 +842,7 @@
             background: rgba(252, 248, 215, 0.95);
         }
 
-        .ajs-close {
+        .close {
             position: absolute;
             top: 0px;
             right: 0px;


### PR DESCRIPTION
This PR adds the option *closeButton* to the notifier. When *true*, the clickHandler to close the notification will be applied to a small close button positioned to the right of the message. 

This feature helps users copy/paste the contents of a message (currently, the click handler on the message makes this impossible). 