### PR TITLE
Handle clicks on the button child elements

### DIFF
--- a/build/alertify.js
+++ b/build/alertify.js
@@ -1297,7 +1297,7 @@
             var target = event.srcElement || event.target;
             triggerCallback(instance, function (button) {
                 // if this button caused the click, cancel keyup event
-                return button.element === target && (cancelKeyup = true);
+                return button.element.contains(target) && (cancelKeyup = true);
             });
         }
 

--- a/src/js/dialog/actions.js
+++ b/src/js/dialog/actions.js
@@ -41,7 +41,7 @@
             var target = event.srcElement || event.target;
             triggerCallback(instance, function (button) {
                 // if this button caused the click, cancel keyup event
-                return button.element === target && (cancelKeyup = true);
+                return button.element.contains(target) && (cancelKeyup = true);
             });
         }
 


### PR DESCRIPTION
Hi! The buttons are not clickable if the button titles are wrapped inside some HTML elements (child elements of the buttons).

So instead checking the click target, better check whether the button contains the target element.

(I can contribute more improvements, if you're interested, but this one is really important.)